### PR TITLE
add: i18n（国際化）対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 __pycache__
 GameConsoleActivitytoDiscord
 GameConsoleActivitytoDiscord-win.zip
+lang/lang.txt
+.vscode

--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-pypresence = "==3.3.2"
-pywin32 = "*"
+pypresence = "==3.0.0"
+pywin32 = "==227"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "686b0b9bdee175e4b2378bf186609b7d0779b76a6f275d63f99974b81807b4d5"
+            "sha256": "f01ab800213692d3dff9d90605fc9b7bf085a49f6b1fbc0979cf3d116a461cf6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "pypresence": {
             "hashes": [
-                "sha256:d39f8eb79c521ae2f3dd8e2dbfa204d7df4201f044b68bcae6339c75b87dfb7b"
+                "sha256:ae14bbd5d6209187c36ad28811b99d8180829fb49b78336658fcc2b2ad4b5b7b"
             ],
             "index": "pypi",
-            "version": "==3.3.2"
+            "version": "==3.0.0"
         },
         "pywin32": {
             "hashes": [

--- a/config.py
+++ b/config.py
@@ -3,9 +3,28 @@ import os
 
 config_json = []
 
+# i18n
+LANG_LIST = ["en", "ja"]
+if not os.path.exists("./lang/lang.txt"):
+    lang = input("Which language? (English=en, 日本語=ja): ")
+    if not lang in LANG_LIST:
+        print("Invalid lang / 無効な言語です")
+        exit()
+    with open("./lang/lang.txt", "w", encoding="utf-8") as f:
+        f.write(lang)
+else:
+    with open("./lang/lang.txt", "r", encoding="utf-8") as f:
+        lang = f.read()
+
+
+message = {}
+with open(f'./lang/{lang}.json', "r", encoding="utf-8") as f:
+    message = json.load(f)
+
 
 def delete_console():
     global config_json
+    global message
 
     cnt = 0
     print("-" * 30)
@@ -20,32 +39,26 @@ def delete_console():
     end_code = cnt
     delete_num = -1
     while not 0 <= delete_num <= end_code:
-        print("\nSelect console you want to delete (type [%d] to cancel)\nType number [0-%d]?" % (end_code, end_code))
+        print(message["delete_console"].format(end_code, end_code))
         delete_num = int(input())
     if delete_num == end_code:
         return
     config_json.pop(delete_num)
-    print("Deleted.")
+    print(message["deleted"])
 
 
 def add_new_console():
+    global message
+
     console = 100
     while not 0 <= console <= 4:
-        print("""
-Select your Game Console!
-[0] Nintendo Switch
-[1] Nintendo 3DS
-[2] PS3
-[3] PS4
-[4] Others
-
-Type number [0-4]?""")
+        print(message["add_console"])
         console = int(input())
     jsonar = {"console": console}
     if console == 4:
-        print("Type your console name!")
+        print(message["type_console_name"])
         jsonar.update({"custom": input()})
-    print("Type IP address of your console!")
+    print(message["type_console_ip"])
     jsonar.update({"ip": input()})
     return jsonar
 
@@ -69,16 +82,10 @@ while True:
         print("-" * 30)
     setting_option = 100
     while not 0 <= setting_option <= 2:
-        print("""
-Configuration
-[0] Add new console
-[1] Delete console
-[2] Exit
-
-Type number [0-2]?""")
+        print(message["config_main_menu"])
         setting_option = int(input())
     if setting_option == 2:
-        print("Good bye")
+        print(message["goodby"])
         exit()
 
     if setting_option == 0:
@@ -87,11 +94,11 @@ Type number [0-2]?""")
         fw = open("config.json", "w")
         json.dump(config_json, fw)
         fw.close()
-        print("Added!")
+        print(message["added"])
 
     if setting_option == 1:
         if not config_json:
-            print("Nothing to delete!")
+            print(message["console_not_found"])
         else:
             delete_console()
             if not config_json:

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,5 +8,14 @@
     "add_console": "Select your Game Console!\n[0] Nintendo Switch\n[1] Nintendo 3DS\n[2] PS3\n[3] PS4\n[4] Others\n\nType number [0-4]?",
     "deleted": "Deleted.",
     "delete_console": "Select console you want to delete (type [{}] to cancel)\nType number [0-{}]?",
-    "set_config_first": "First you have to run config.py(config.exe) to config.\nPress enter to exit..."
+    "set_config_first": "First you have to run config.py(config.exe) to config.\nPress enter to exit...",
+    "connection_lost": "Connection lost... ( {} / 2 tried )",
+    "turned_off": "Device turned off.",
+    "turned_on": "Your {}[{}] turned on! Have fun!",
+    "connected": "Connected.",
+    "start": "Service starting...",
+    "win_only": "I'm sorry but this will work for Windows only...\nPress enter to close...",
+    "confirm_startup": "Setup to run this app when you booted up this PC, Okay?\nPress enter to continue... ( Ctrl + C to cancel )\n",
+    "canceled": "Canceled.",
+    "startup_done": "Done!\nPress enter to close..."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,12 @@
+{
+    "config_main_menu": "Configuration\n[0] Add new console\n[1] Delete console\n[2] Exit\n\nType number [0-2]?",
+    "goodby": "Good bye",
+    "added": "Added!",
+    "console_not_found": "Nothing to delete!",
+    "type_console_name": "Type your console name!",
+    "type_console_ip": "Type IP address of your console!",
+    "add_console": "Select your Game Console!\n[0] Nintendo Switch\n[1] Nintendo 3DS\n[2] PS3\n[3] PS4\n[4] Others\n\nType number [0-4]?",
+    "deleted": "Deleted.",
+    "delete_console": "Select console you want to delete (type [{}] to cancel)\nType number [0-{}]?",
+    "set_config_first": "First you have to run config.py(config.exe) to config.\nPress enter to exit..."
+}

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -8,5 +8,14 @@
     "add_console": "あなたのゲーム機を選択してください！\n[0] Nintendo Switch\n[1] Nintendo 3DS\n[2] PS3\n[3] PS4\n[4] その他\n\n[0-4] から数字を入力してください。",
     "deleted": "削除しました。",
     "delete_console": "削除したいゲーム機を選択してください！ ([{}] を入力でキャンセル)\n[0-{}]から数字を入力してください。",
-    "set_config_first": "はじめに config.py(config.exe) を実行して設定してください。\nEnterを押して終了します..."
+    "set_config_first": "はじめに config.py(config.exe) を実行して設定してください。\nEnterを押して終了します...",
+    "connection_lost": "接続が切断されました... ( 再接続: {} / 2 )",
+    "turned_off": "機器がオフになりました。",
+    "turned_on": "あなたの {}[{}] の接続がオンになりました！楽しんで！",
+    "connected": "接続しました。",
+    "start": "サービスを開始しています...",
+    "win_only": "申し訳ありませんが、この機能はWindows以外では動作しません。\nEnterを押して終了します...",
+    "confirm_startup": "このコンピュータの起動時に自動的にプログラムが起動するように設定します。よろしいですか？\nEnterを押して続行します... ( Ctrl + C でキャンセル )\n",
+    "canceled": "キャンセルしました。",
+    "startup_done": "完了しました。\nEnterを押して終了します..."
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,0 +1,12 @@
+{
+    "config_main_menu": "設定\n[0] 新しいゲーム機の追加\n[1] ゲーム機の削除\n[2] 閉じる\n\n[0-2] から数字を入力してください。",
+    "goodby": "グッバイ！",
+    "added": "追加しました。",
+    "console_not_found": "削除対象がありません！",
+    "type_console_name": "あなたのゲーム機の登録名を入力してください！",
+    "type_console_ip": "あなたのゲーム機のIPアドレスを入力してください！",
+    "add_console": "あなたのゲーム機を選択してください！\n[0] Nintendo Switch\n[1] Nintendo 3DS\n[2] PS3\n[3] PS4\n[4] その他\n\n[0-4] から数字を入力してください。",
+    "deleted": "削除しました。",
+    "delete_console": "削除したいゲーム機を選択してください！ ([{}] を入力でキャンセル)\n[0-{}]から数字を入力してください。",
+    "set_config_first": "はじめに config.py(config.exe) を実行して設定してください。\nEnterを押して終了します..."
+}

--- a/start.py
+++ b/start.py
@@ -47,7 +47,20 @@ except:
     exit()
 
 
-print("Service started...")
+if not os.path.exists("./lang/lang.txt"):
+    input("Can't find lang.txt file. You have to run config.py(config.exe) to config.\nPress enter to exit...")
+    exit()
+else:
+    with open("./lang/lang.txt", "r", encoding="utf-8") as f:
+        lang = f.read()
+
+
+message = {}
+with open(f'./lang/{lang}.json', "r", encoding="utf-8") as f:
+    message = json.load(f)
+
+
+print(message["start"])
 while True:
     for consoles in config:
         client_id = CLIENT_IDS[consoles["console"]]
@@ -64,14 +77,14 @@ while True:
                 # print(ping.stdout.read().decode("cp932"))
                 if return_node == 0:
                     if dscCnt != 0:
-                        print("Connected.")
+                        print(message["connected"])
                     dscCnt = 0
                     if consoles["console"] == 4:
                         cname = consoles["custom"]
                     else:
                         cname = CONSOLE_NAMES[consoles["console"]]
                     if not connected:
-                        print(f"Your {cname}[{consoles['ip']}] turned on! Have fun!")
+                        print(message["turned_on"].format(cname, consoles["ip"]))
                         RPC = Presence(client_id)
                         RPC.connect()  # Start the handshake loop
                         if 0 <= consoles["console"] <= 3:
@@ -84,13 +97,13 @@ while True:
                 else:
                     if connected:
                         if dscCnt == 2:
-                            print("Device turned off.")
+                            print(message["turned_off"])
                             RPC.close()
                             connected = False
                             disConnected = True
                         else:
                             dscCnt += 1
-                            print(f"Connection lost... ( {dscCnt} / 2 )")
+                            print(message["connection_lost"].format(dscCnt))
                 time.sleep(5)
                 ping = send_ping()
                 return_node = ping.wait()

--- a/startup.py
+++ b/startup.py
@@ -1,10 +1,24 @@
 import os
+import json
+
+
+if not os.path.exists("./lang/lang.txt"):
+    input("Can't find lang.txt file. You have to run config.py(config.exe) to config.\nPress enter to exit...")
+    exit()
+else:
+    with open("./lang/lang.txt", "r", encoding="utf-8") as f:
+        lang = f.read()
+
+
+message = {}
+with open(f'./lang/{lang}.json', "r", encoding="utf-8") as f:
+    message = json.load(f)
+
 
 if os.name != "nt":
-    print("I'm sorry but this will work for Windows only...")
-    print("Press enter to close...")
-    gomi = input()
+    input(message["win_only"])
     exit()
+
 
 import win32com.client
 
@@ -25,11 +39,11 @@ def create_short_cut(path, sc_file_name, icon=None):
 
     sh_cut.Save()
 
-
-print("Setup to run this app when you booted up this PC, Okay?")
-print("起動時にこのアプリを起動するよう設定します。よろしいですか？\n")
-input("Press enter to continue...")
+try:
+    input(message["confirm_startup"])
+except:
+    print(message["canceled"])
+    exit()
 
 create_short_cut(f"{os.getcwd()}/start.exe", "GameConsoleActivitytoDiscord")
-print("Done!")
-input("Press enter to close...")
+input(message["startup_done"])


### PR DESCRIPTION
すべてのプログラム
- start.py
- startup.py
- config.py
において、日本語・英語の対応を行いました。

言語は初回起動時config.pyで選択します。     
選択していないとconfig以外は実行できない設定です。

言語ファイルは`lang/*.json`にあります。    
これを配布時zipに入れないと動きません。     
jsonを編集し、選択言語を増やすだけで簡単に言語が追加できる仕様です。

resolve #9 